### PR TITLE
Remove spaces caused by multiple unprinted acros

### DIFF
--- a/acronym.dtx
+++ b/acronym.dtx
@@ -1099,7 +1099,8 @@ blocks to be tested separately. The latter are commonly indicated as
     \protected@write\@auxout{}%
        {\string\newacro{#1}[\string\AC@hyperlink{#1}{#2}]{#3}}%
     \@esphack
-  \endgroup}
+  \endgroup
+  \ignorespaces}
 %    \end{macrocode}
 %    \end{macro}
 %    \end{macro}


### PR DESCRIPTION
Add \ignorespaces after the \endgroup in the \AC@@acro definition to gobble up spaces introduced by multiple \@bsphack and \@esphack pairs.