### PR TITLE
Fixed Unconventional Dots Spacing in List of Acronyms

### DIFF
--- a/acronym.dtx
+++ b/acronym.dtx
@@ -1179,7 +1179,11 @@ blocks to be tested separately. The latter are commonly indicated as
   \else%
   \ifAC@printonlyused%
     \expandafter\ifx\csname acused@#1\endcsname\AC@used%
-       \item[\protect\AC@hypertarget{#1}{\aclabelfont{#2}}] #3%
+      \ifAC@nohyperlinks%
+        \item[\protect\AC@hypertarget{#1}{\aclabelfont{#2}}] #3%
+      \else%
+        \item[\protect\AC@hypertarget{#1}{\hyperref[acro:#1]{\aclabelfont{#2}\hfill}}]\hyperref[acro:#1]{#3}%
+      \fi%
           \ifAC@withpage%
             \expandafter\ifx\csname r@acro:#1\endcsname\relax%
                \PackageInfo{acronym}{%
@@ -1191,10 +1195,14 @@ blocks to be tested separately. The latter are commonly indicated as
             \fi%
           \fi\\%
     \fi%
- \else%
-    \item[\protect\AC@hypertarget{#1}{\aclabelfont{#2}}] #3%
- \fi%
- \fi%
+  \else%
+    \ifAC@nohyperlinks%
+      \item[\protect\AC@hypertarget{#1}{\aclabelfont{#2}}] #3%
+    \else%
+      \item[\protect\AC@hypertarget{#1}{\hyperref[acro:#1]{\aclabelfont{#2}\hfill}}]\hyperref[acro:#1]{#3}%
+    \fi%
+  \fi%
+  \fi%
  \begingroup
     \def\acroextra##1{}%
     \@bsphack

--- a/acronym.dtx
+++ b/acronym.dtx
@@ -1186,7 +1186,8 @@ blocks to be tested separately. The latter are commonly indicated as
                  Acronym #1 used in text but not spelled out in
                  full in text}%
             \else%
-               \dotfill\pageref{acro:#1}%
+              \nobreak\leaders\hbox{$\m@th\mkern\@dotsep mu\hbox{.}\mkern\@dotsep mu$}\hfill%
+              \nobreak\hb@xt@\@pnumwidth{\hfil\normalfont\normalcolor\pageref*{acro:#1}}%
             \fi%
           \fi\\%
     \fi%


### PR DESCRIPTION
Fixes the issue that an unconventional spacing is used between the dots in the list of acronyms. The dots are visible as soon as the `withpage` option is enabled. The applied fix changes the dot spacing to be the same as in all other lists, such as the table of contents or the list of listings.