### PR TITLE
Added `\AC@hyperref` and `\AC@pageref` Dummy Commands

### DIFF
--- a/acronym.dtx
+++ b/acronym.dtx
@@ -35,7 +35,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{1459}
+% \CheckSum{1454}
 %
 %% \CharacterTable
 %%  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -849,23 +849,19 @@ blocks to be tested separately. The latter are commonly indicated as
 %    \begin{macro}{\AC@hyperlink}
 %    \begin{macro}{\AC@hyperref}
 %    \begin{macro}{\AC@hypertarget}
+%    \begin{macro}{\AC@phantomsection}
 %    Define dummy hyperlink commands
 %    \begin{macrocode}
 \def\AC@hyperlink#1#2{#2}
 \def\AC@hyperref[#1]#2{#2}
 \def\AC@hypertarget#1#2{#2}
-\AtBeginDocument{
-  \@ifpackageloaded{hyperref}{%
-    \def\AC@pageref{\pageref*}%
-  }{%
-    \def\AC@pageref{\pageref}%
-  }
-}
 \def\AC@phantomsection{}
 %    \end{macrocode}
 %    \end{macro}
 %    \end{macro}
 %    \end{macro}
+%    \end{macro}
+%
 %    \begin{macro}{\AC@raisedhypertarget}
 %    Make sure that hyperlink processing gets enabled before we process
 %    the document if hyperref has been loaded in the mean time.
@@ -888,6 +884,19 @@ blocks to be tested separately. The latter are commonly indicated as
           }%
          }{}}%
 \fi
+%    \end{macrocode}
+%    \end{macro}
+%
+%    \begin{macro}{\AC@pageref}
+%    Use |\pageref*| instead of |\pageref| when the |hyperref| package is used.
+%    \begin{macrocode}
+\AtBeginDocument{%
+  \@ifpackageloaded{hyperref}{%
+    \let\AC@pageref=\@pagerefstar%
+  }{%
+    \let\AC@pageref=\pageref%
+  }%
+}
 %    \end{macrocode}
 %    \end{macro}
 %

--- a/acronym.dtx
+++ b/acronym.dtx
@@ -66,7 +66,7 @@
 %             \ensuremath, \expandafter}
 % \DoNotIndex{\fi, \footnote}
 % \DoNotIndex{\gdef, \global}
-% \DoNotIndex{\hfill, \hyperlink, \hypertarget}
+% \DoNotIndex{\hfill, \hyperlink, \hyperref, \hypertarget}
 % \DoNotIndex{\if@filesw, \ifx, \item}
 % \DoNotIndex{\label, \labelsep, \labelwidth, \leftmargin, \let,
 %             \long}
@@ -854,6 +854,13 @@ blocks to be tested separately. The latter are commonly indicated as
 \def\AC@hyperlink#1#2{#2}
 \def\AC@hyperref[#1]#2{#2}
 \def\AC@hypertarget#1#2{#2}
+\AtBeginDocument{
+  \@ifpackageloaded{hyperref}{%
+    \def\AC@pageref{\pageref*}%
+  }{%
+    \def\AC@pageref{\pageref}%
+  }
+}
 \def\AC@phantomsection{}
 %    \end{macrocode}
 %    \end{macro}
@@ -1213,11 +1220,7 @@ blocks to be tested separately. The latter are commonly indicated as
   \else%
   \ifAC@printonlyused%
     \expandafter\ifx\csname acused@#1\endcsname\AC@used%
-      \ifAC@nohyperlinks%
-        \item[\protect\AC@hypertarget{#1}{\aclabelfont{#2}}] #3%
-      \else%
-        \item[\protect\AC@hypertarget{#1}{\AC@hyperref[acro:#1]{\aclabelfont{#2}\hfill}}]\AC@hyperref[acro:#1]{#3}%
-      \fi%
+      \item[\protect\AC@hypertarget{#1}{\AC@hyperref[acro:#1]{\aclabelfont{#2}\hfill}}]\AC@hyperref[acro:#1]{#3}%
           \ifAC@withpage%
             \expandafter\ifx\csname r@acro:#1\endcsname\relax%
                \PackageInfo{acronym}{%
@@ -1225,22 +1228,14 @@ blocks to be tested separately. The latter are commonly indicated as
                  full in text}%
             \else%
               \nobreak\leaders\hbox{$\m@th\mkern\@dotsep mu\hbox{.}\mkern\@dotsep mu$}\hfill%
-              \nobreak\hb@xt@\@pnumwidth{\hfil\normalfont\normalcolor%
-                \ifAC@nohyperlinks%
-                  \pageref{acro:#1}%
-                \else%
-                  \pageref*{acro:#1}%
-                \fi%
+              \nobreak\hb@xt@\@pnumwidth{%
+                \hfil\normalfont\normalcolor\AC@pageref{acro:#1}%
               }%
             \fi%
           \fi\\%
     \fi%
   \else%
-    \ifAC@nohyperlinks%
-      \item[\protect\AC@hypertarget{#1}{\aclabelfont{#2}}] #3%
-    \else%
-      \item[\protect\AC@hypertarget{#1}{\AC@hyperref[acro:#1]{\aclabelfont{#2}\hfill}}]\AC@hyperref[acro:#1]{#3}%
-    \fi%
+    \item[\protect\AC@hypertarget{#1}{\AC@hyperref[acro:#1]{\aclabelfont{#2}\hfill}}]\AC@hyperref[acro:#1]{#3}%
   \fi%
   \fi%
  \begingroup

--- a/acronym.dtx
+++ b/acronym.dtx
@@ -847,13 +847,16 @@ blocks to be tested separately. The latter are commonly indicated as
 %    \subsection{Hyperlinks and PDF support}
 %
 %    \begin{macro}{\AC@hyperlink}
+%    \begin{macro}{\AC@hyperref}
 %    \begin{macro}{\AC@hypertarget}
 %    Define dummy hyperlink commands
 %    \begin{macrocode}
 \def\AC@hyperlink#1#2{#2}
+\def\AC@hyperref[#1]#2{#2}
 \def\AC@hypertarget#1#2{#2}
 \def\AC@phantomsection{}
 %    \end{macrocode}
+%    \end{macro}
 %    \end{macro}
 %    \end{macro}
 %    \begin{macro}{\AC@raisedhypertarget}
@@ -865,6 +868,7 @@ blocks to be tested separately. The latter are commonly indicated as
    \AtBeginDocument{%
       \@ifpackageloaded{hyperref}
          {\let\AC@hyperlink=\hyperlink
+          \let\AC@hyperref=\hyperref
           \newcommand*\AC@raisedhypertarget[2]{%
              \Hy@raisedlink{\hypertarget{#1}{}}#2}%
           \let\AC@hypertarget=\AC@raisedhypertarget
@@ -1212,7 +1216,7 @@ blocks to be tested separately. The latter are commonly indicated as
       \ifAC@nohyperlinks%
         \item[\protect\AC@hypertarget{#1}{\aclabelfont{#2}}] #3%
       \else%
-        \item[\protect\AC@hypertarget{#1}{\hyperref[acro:#1]{\aclabelfont{#2}\hfill}}]\hyperref[acro:#1]{#3}%
+        \item[\protect\AC@hypertarget{#1}{\AC@hyperref[acro:#1]{\aclabelfont{#2}\hfill}}]\AC@hyperref[acro:#1]{#3}%
       \fi%
           \ifAC@withpage%
             \expandafter\ifx\csname r@acro:#1\endcsname\relax%
@@ -1235,7 +1239,7 @@ blocks to be tested separately. The latter are commonly indicated as
     \ifAC@nohyperlinks%
       \item[\protect\AC@hypertarget{#1}{\aclabelfont{#2}}] #3%
     \else%
-      \item[\protect\AC@hypertarget{#1}{\hyperref[acro:#1]{\aclabelfont{#2}\hfill}}]\hyperref[acro:#1]{#3}%
+      \item[\protect\AC@hypertarget{#1}{\AC@hyperref[acro:#1]{\aclabelfont{#2}\hfill}}]\AC@hyperref[acro:#1]{#3}%
     \fi%
   \fi%
   \fi%


### PR DESCRIPTION
Restores the old behaviour that the document compiles even without the `hyperref` package loaded.