### PR TITLE
fixes printonlyreused bug #25

### DIFF
--- a/acronym.dtx
+++ b/acronym.dtx
@@ -35,7 +35,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{1529}
+% \CheckSum{1528}
 %
 %% \CharacterTable
 %%  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -1040,7 +1040,6 @@ blocks to be tested separately. The latter are commonly indicated as
 %    acronyms is in the front matter of the document.
 %    \begin{macrocode}
 \newcommand*{\AC@logged}[1]{%
-   \acronymused{#1}% mark it as used in the current run too
    \@bsphack
    \protected@write\@auxout{}{\string\acronymused{#1}}%
    \@esphack}


### PR DESCRIPTION
In the old version the output depended on the position of the list of acronyms due to double `\acronymused` commands. @oetiker could you please recall why the command was executed on the first run, too?

E.g.
```
\documentclass[12pt]{article}
\usepackage[printonlyused]{acronym}
\begin{document}
  \ac{T}
  \begin{acronym}
    \acro{T}{Test}
  \end{acronym}
\end{document}
```
and
```
\documentclass[12pt]{article}
\usepackage[printonlyused]{acronym}
\begin{document}
  \begin{acronym}
    \acro{T}{Test}
  \end{acronym}
  \ac{T}
\end{document}
```
produce different output in the first run. The `printonlyreused` option will unfortunately fail if the list comes after the acronyms are used as described in #25.