### PR TITLE
Correct capitalization of acronym with custom plural (fixes #45)

### DIFF
--- a/acronym.dtx
+++ b/acronym.dtx
@@ -2,7 +2,7 @@
 %
 % Doc-Source file to use with LaTeX2e
 %
-% Copyright 1994-2020 by Tobias Oetiker (tobi@oetiker.ch) and many Contributors.
+% Copyright 1994-2021 by Tobias Oetiker (tobi@oetiker.ch) and many Contributors.
 % All rights reserved.
 %
 % This work may be distributed and/or modified under the conditions of
@@ -35,7 +35,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{1600}
+% \CheckSum{1608}
 %
 %% \CharacterTable
 %%  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -82,6 +82,7 @@
 % \DoNotIndex{\textbf, \textsf, \textsmaller, \textsuperscript, \the}
 % \DoNotIndex{\usepackage}
 %
+%  \changes{v1.48}{2021/10/09}{Bruno Le Floch corrected capitalization of acronyms with a custom plural form.}
 %  \changes{v1.47}{2020/04/10}{Tobi Oetiker and Marcus Meeßen \cmd{hskip} Fixed several bugs in macros that use capitalisation, a bug were the output depends on the position of the list of acronyms, and a bug were nested hyperlinks could cause errors.}
 %  \changes{v1.46}{2020/03/13}{Tobi Oetiker \cmd{hskip} Fixed miss merge}
 %  \changes{v1.45}{2020/03/13}{Marcus Meeßen \cmd{hskip} Fixed hyperref and "missing aux" regressions.}
@@ -691,8 +692,8 @@ blocks to be tested separately. The latter are commonly indicated as
 %    First we test that we got the right format and name the package.
 %    \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}[1999/12/01]
-\ProvidesPackage{acronym}[2020/04/17
-                          v1.47
+\ProvidesPackage{acronym}[2021/10/09
+                          v1.48
                           Support for acronyms (Tobias Oetiker)]
 \RequirePackage{suffix,xstring}
 %    \end{macrocode}
@@ -1089,12 +1090,19 @@ blocks to be tested separately. The latter are commonly indicated as
 %    \end{macro}
 %    \end{macro}
 %
-%    \begin{macro}{\@firstupper}
+%    \begin{macro}{\@firstupper,\@firstupper@maybe}
 %    Internal commands for making a first letter upper case.
 %    \begin{macrocode}
 \newcommand{\@firstupper}[1]{%
   \StrSplit{#1}{1}{\head}{\tail}%
   \MakeUppercase\head\tail%
+}
+\newcommand{\@firstupper@maybe}{%
+  \ifAC@upper
+    \expandafter\@firstupper
+  \else
+    \expandafter\@firstofone
+  \fi
 }
 %    \end{macrocode}
 %    \end{macro}
@@ -1444,7 +1452,7 @@ blocks to be tested separately. The latter are commonly indicated as
 %   \begin{macrocode}
 \newcommand*\AC@aclp[1]{%
   \ifcsname fn@#1@PL\endcsname
-  \csname fn@#1@PL\endcsname
+    \@firstupper@maybe{\csname fn@#1@PL\endcsname}%
   \else
   \AC@acl{#1}s%
   \fi
@@ -1503,11 +1511,7 @@ blocks to be tested separately. The latter are commonly indicated as
     \PackageWarning{acronym}{Acronym `#3' is not defined}%
     \textbf{#3!}%
   \else
-    \ifAC@upper
-      \@firstupper{\expandafter#2#1}%
-    \else
-      \expandafter#2#1%
-    \fi
+    \@firstupper@maybe{\expandafter#2#1}%
   \fi
 }
 %    \end{macrocode}
@@ -1813,12 +1817,12 @@ blocks to be tested separately. The latter are commonly indicated as
 \newcommand*{\@iaci}[1]{%
   \ifcsname fn@#1@IL\endcsname
     \ifAC@dua
-      \csname fn@#1@IL\endcsname%
+      \@firstupper@maybe{\csname fn@#1@IL\endcsname}%
     \else
       \expandafter\ifx\csname AC@\AC@prefix#1\endcsname\AC@used%
         \csname fn@#1@IS\endcsname%
       \else
-        \csname fn@#1@IL\endcsname%
+        \@firstupper@maybe{\csname fn@#1@IL\endcsname}%
       \fi
     \fi
   \else

--- a/acronym.ins
+++ b/acronym.ins
@@ -4,7 +4,7 @@
 %% driver files from the doc files in this package when run through
 %% LaTeX or TeX.
 %%
-%% Copyright 1995--2020  by Tobias Oetiker (tobi@oetiker.ch)
+%% Copyright 1995--2021  by Tobias Oetiker (tobi@oetiker.ch)
 %%                       and individual authors listed elsewhere
 %%                       in this file.
 %% All rights reserved.
@@ -31,7 +31,7 @@
 \keepsilent
 
 \preamble
- Copyright 1995--2020  by Tobias Oetiker (tobi@oetiker.ch)
+ Copyright 1995--2021  by Tobias Oetiker (tobi@oetiker.ch)
                        and individual authors listed elsewhere.
  All rights reserved.
 


### PR DESCRIPTION
- Please check: since there are very few tests I'm not confident that I got everything right.  Basically I looked for `fn@…@…` as these seem to be where custom plurals or indefinite articles are stored.
- Hopefully I got the `\changes` entry, copyright year, and new version number correct.