### PR TITLE
Add option 'error' for undefined acronym handling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Version 1.49 (Sep 2024)
+- Adds error option
+-- Theo von Arx
+
 Version 1.48 (Mar 2024)
 
 - Adds noforwardlinks option
@@ -24,7 +28,7 @@ Version 1.45 (Mar 2020)
 
 -  Fixed hyperref regression and the longstanding "missing aux" bug.
 -- Marcus Meeßen
- 
+
 Version 1.44 (Feb 2020)
 
 - added the |printonlyreused| option, which allows to automatically exclude acronyms from the list of acronyms if they are used only once
@@ -54,7 +58,7 @@ two features were added -- Oz Davidi
  * Now it is possible to forbid a line break between the full name and the short name (when they are printed together). It is possible to control it individually (for each command), and also globally (with the |nolinebreak| option).
  * Added the \Ac{p,f,fp,l,lp,lu} commands. They work exactly the same way as the \ac commands, but prints the full name, starting with an upper case letter (in case it was defined with a lower case letter).
 
-correting issue with long lines due to carriage return misplaced -- Philippe Chauvat 
+correting issue with long lines due to carriage return misplaced -- Philippe Chauvat
 
 Version 1.41 (Mar 2015)
 
@@ -76,7 +80,7 @@ has its optional argument provided
 Version 1.38 (Oct 2012)
 
 add support for dynamic indefinite articles depending on the acronym form used
--- Ash Hughes 
+-- Ash Hughes
 
 fix for non hyphenation of first word in long form
 -- Martin Rüßler
@@ -133,14 +137,14 @@ Version 1.26 (June 2006) supress lone item when nolist is in effect
 Version 1.25 (November 2005) properly handle acronyms in pdfbookmarks
 -- Heiko Oberdiek <oberdiek there uni-freiburg.de>
 
-Version 1.24 (October 2005) ac* commands are now not fragile anymore ... 
+Version 1.24 (October 2005) ac* commands are now not fragile anymore ...
 -- José Emilio Vila Forcén jose.vila there cui.unige.ch
 
 Version 1.23 (October 2005) fixed typo in nolist option. added comment about fragility of ac commands.
 -- Tobias Oetiker (tobi with oetiker.ch)
 
 Version 1.22 (October 2005) added starred versions of ac(p), acf(p), acs(p),
-acl(p), acfi, acsu & aclu 
+acl(p), acfi, acsu & aclu
 -- Stefan Pinnow (Mo-Gul here gmx.net)
 
 Version 1.21 (September 2005): fixed the  \acused command again ... broke it
@@ -207,8 +211,8 @@ acronym. Add footnote optional out for \cmd{\acs}. Fix for list of acronyms
 in front matter and addition of \cmd{\acroextra} command.
 -- Danie Els <dnjels there sun.ac.za>
 
-Version 1.9 (October 2003): Fix hyperref processing to work regardles 
-of calling order. 'printused' now prints every acronym used not only 
+Version 1.9 (October 2003): Fix hyperref processing to work regardles
+of calling order. 'printused' now prints every acronym used not only
 the ones called through \ac.
 -- Danie Els <dnjels there sun.ac.za> and Tobi Oetiker
 
@@ -218,12 +222,12 @@ definition.
 -- Martin Salois <Martin.Salois there drdc-rddc.gc.ca>
 
 Version 1.7 (September 2003): Added \acresetall for resetting the 'used'-tag
-of \ac. With the new option 'printonlyused', the acronym-list will consist of 
-the used acronyms only and not of all defined acronyms; Optional in a special 
+of \ac. With the new option 'printonlyused', the acronym-list will consist of
+the used acronyms only and not of all defined acronyms; Optional in a special
 deflist - environment.
 -- Sebastian Max <smx there comnets.rwth-aachen.de>
 
-Version 1.6 (May 2000): Added the smaller option and the macros \acsfont, 
+Version 1.6 (May 2000): Added the smaller option and the macros \acsfont,
 \acffont, and \acfsfont used to control the appearance of  \acs and \acf.
 -- Ingo Lepper <lepper there math.uni-muenster.de>
 

--- a/acronym.dtx
+++ b/acronym.dtx
@@ -35,7 +35,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{1658}
+% \CheckSum{1664}
 %
 %% \CharacterTable
 %%  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z

--- a/acronym.dtx
+++ b/acronym.dtx
@@ -35,7 +35,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{1634}
+% \CheckSum{1652}
 %
 %% \CharacterTable
 %%  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -73,7 +73,7 @@
 % \DoNotIndex{\makelabel, \mathrm}
 % \DoNotIndex{\NeedsTeXFormat, \newcommand, \newenvironment,
 %             \newif, \newtoks, \noexpand, \nolinebreak, \null}
-% \DoNotIndex{\PackageWarning, \ProcessOptions, \protect,
+% \DoNotIndex{\PackageWarning, \PackageError, \ProcessOptions, \protect,
 %             \protected@write, \providecommand, \ProvidesPackage}
 % \DoNotIndex{\raggedright, \ref, \relax, \renewcommand,
 %             \RequirePackage}
@@ -82,6 +82,7 @@
 % \DoNotIndex{\textbf, \textsf, \textsmaller, \textsuperscript, \the}
 % \DoNotIndex{\usepackage}
 %
+%  \changes{v1.50}{2024/09/26}{Theo von Arx adds the option 'error' to throw errors upon undefined acronyms}
 %  \changes{v1.49}{2024/03/30}{Chris Landis adds noforwardlinks option and fixes targets for forward links to acs/acl/etc.-only use}
 %  \changes{v1.48}{2021/10/09}{Bruno Le Floch corrected capitalization of acronyms with a custom plural form.}
 %  \changes{v1.47}{2020/04/10}{Tobi Oetiker and Marcus Meeßen \cmd{hskip} Fixed several bugs in macros that use capitalisation, a bug were the output depends on the position of the list of acronyms, and a bug were nested hyperlinks could cause errors.}
@@ -702,6 +703,17 @@ blocks to be tested separately. The latter are commonly indicated as
 %
 %
 % \subsection{Options}
+%
+%    \begin{macro}{\ifAC@error}
+%    The option |error| lets this package throw compile errors instead of warnings in case of undefined acronyms.
+%    \begin{macrocode}
+\newif\ifAC@error
+\AC@errorfalse
+%    \end{macrocode}
+%    \begin{macrocode}
+\DeclareOption{error}{\AC@errortrue}
+%    \end{macrocode}
+%    \end{macro}
 %
 %    \begin{macro}{\ifAC@footnote}
 %    The option |footnote| leads to a redefinition of \cmd{\acf},
@@ -1510,10 +1522,29 @@ blocks to be tested separately. The latter are commonly indicated as
 %    \end{macrocode}
 %    \end{macro}
 %
-%    \begin{macro}{\AC@get}
-%    If the acronym is undefined, the internal macro \cmd{\AC@get}
-%    warns the user by printing the name in bold with an exclamation
+%    \begin{macro}{\AC@logundefined}
+%    The internal macro \cmd{\AC@logundefined} either throws a warning or an error
+%    (if option |error| is set) and prints the name of the acronym in bold with an exclamation
 %    mark at the end.
+%    \begin{macrocode}
+\newcommand\AC@logundefined[1]{%
+  \ifAC@error%
+    \ifx\AC@populated\AC@used%
+      \PackageError{acronym}{#1}{You should define the acronym with
+        \protect\acrodef, \protect\newacro, or \protect\acro.}
+    \else%
+      \PackageWarning{acronym}{#1}%
+    \fi%
+  \else%
+    \PackageWarning{acronym}{#1}%
+  \fi%
+}
+%    \end{macrocode}
+%    \end{macro}
+%
+%    \begin{macro}{\AC@get}
+%    If the acronym is undefined, call the internal macro \cmd{\AC@undefined}
+%    for error handling.
 %    If defined, \cmd{\AC@get} uses the same mechanism used by the LaTeX
 %    kernel commands \cmd{\ref} and \cmd{\pageref} to return the short
 %    \cmd{\AC@acs} and long forms \cmd{\AC@acl} of the acronym
@@ -1521,7 +1552,7 @@ blocks to be tested separately. The latter are commonly indicated as
 %    \begin{macrocode}
 \newcommand*\AC@get[3]{%
   \ifx#1\relax
-    \PackageWarning{acronym}{Acronym `#3' is not defined}%
+    \AC@logundefined{Acronym #3 is not defined}%
     \textbf{#3!}%
   \else
     \@firstupper@maybe{\expandafter#2#1}%

--- a/acronym.dtx
+++ b/acronym.dtx
@@ -35,7 +35,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{1652}
+% \CheckSum{1658}
 %
 %% \CharacterTable
 %%  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z


### PR DESCRIPTION
When 'error' is set, an undefined acronym will throw an error instead of just a warning and thus nudge users to fix the erroneous acronym.

This is my first look behind a usepackage! So any tips/improvements are welcome :)

This closes #58 .